### PR TITLE
Return 200 empty array for no devices

### DIFF
--- a/api/devices.go
+++ b/api/devices.go
@@ -10,9 +10,9 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
-	"fmt"
 
 	"github.com/mainflux/mainflux-core/db"
 	"github.com/mainflux/mainflux-core/models"
@@ -25,7 +25,6 @@ import (
 	"net/http"
 
 	"github.com/go-zoo/bone"
-
 )
 
 /** == Functions == */
@@ -98,12 +97,6 @@ func getDevices(w http.ResponseWriter, r *http.Request) {
 	if err := Db.C("devices").Find(nil).All(&results); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		str := `{"response": "` + err.Error() + `"}`
-		io.WriteString(w, str)
-		return
-	}
-	if len(results) == 0 {
-		w.WriteHeader(http.StatusNotFound)
-		str := `{"response": "no device found"}`
 		io.WriteString(w, str)
 		return
 	}


### PR DESCRIPTION
On `GET /devices` if no devices are stored a `404` error is returned. Technically speaking the request is still successful, there are just no devices to return. This changes the response to be a `200` and return an empty array representing the current "successful" list of devices (empty).

I'm not sure on how versioning is setup with this project and I understand this could break some backwards compatibility. So I'm just throwing it out there for your consideration.

PS Looks like the go formatter changed some things around I didn't intend. I can revert those back if you'd like.

Thanks!